### PR TITLE
ui: 키보드 단축키가 iPadOS의 포커스 시스템과 충돌하던 문제 수정

### DIFF
--- a/reazure/fediverse/SharedClient.swift
+++ b/reazure/fediverse/SharedClient.swift
@@ -26,6 +26,7 @@ enum Tab {
 }
 
 class SharedClient: ObservableObject {
+    static let shared = SharedClient()
     
     @Published
     var account: Account? {
@@ -75,7 +76,7 @@ class SharedClient: ObservableObject {
     
     var replyTo = CurrentValueSubject<StatusAdaptor?, Never>(nil)
     
-    init() {
+    private init() {
         self.constructTimelineModel()
     }
     

--- a/reazure/reazureApp.swift
+++ b/reazure/reazureApp.swift
@@ -17,7 +17,7 @@ struct reazureApp: App {
     private var accountManager = AccountManager()
     
     @StateObject
-    private var sharedClient = SharedClient()
+    private var sharedClient = SharedClient.shared
 
     @UIApplicationDelegateAdaptor
     private var appDelegate: AppDelegate

--- a/reazure/views/AboutAppView.swift
+++ b/reazure/views/AboutAppView.swift
@@ -174,7 +174,7 @@ struct AboutAppView: View {
 
 #Preview {
     AboutAppView(addAccountHandler: {})
-        .environmentObject(SharedClient())
+        .environmentObject(SharedClient.shared)
         .environmentObject(AccountManager())
         .environmentObject(PreferencesManager())
 }

--- a/reazure/views/AppRootView.swift
+++ b/reazure/views/AppRootView.swift
@@ -86,12 +86,10 @@ struct AppRootView: View {
                 
                 if preferencesManager.showExtKeypad {
                     ExtKeypad()
-                } else {
-                    // 단축키는 먹어야 하니까..
-                    ExtKeypad()
-                        .frame(width: 0, height: 0)
-                        .hidden()
                 }
+                
+                ShortcutHandler()
+                    .frame(width: 0, height: 0)
             }
             .background(palette.shell32Background)
             .watchAccountManager {

--- a/reazure/views/AppRootView.swift
+++ b/reazure/views/AppRootView.swift
@@ -113,6 +113,6 @@ struct AppRootView: View {
 #Preview {
     AppRootView()
         .environmentObject(AccountManager())
-        .environmentObject(SharedClient())
+        .environmentObject(SharedClient.shared)
         .environmentObject(PreferencesManager())
 }

--- a/reazure/views/core/ExtKeypad.swift
+++ b/reazure/views/core/ExtKeypad.swift
@@ -88,26 +88,18 @@ struct ExtKeypad: View {
         let h = KeypadButton(label: .constant("h"), sublabel: .constant("←")) {
             sharedClient.handleShortcut(key: .h)
         }
-            .keyboardShortcut(.leftArrow, modifiers: [])
         
         let j = KeypadButton(label: .constant("j"), sublabel: .constant("↓")) {
             sharedClient.handleShortcut(key: .j)
         }
-            .platformMask([.iOS, .macOS]) { view in
-                view.keyboardShortcut(.downArrow, modifiers: [])
-            }
         
         let k = KeypadButton(label: .constant("k"), sublabel: .constant("↑")) {
             sharedClient.handleShortcut(key: .k)
         }
-            .platformMask([.iOS, .macOS]) { view in
-                view.keyboardShortcut(.upArrow, modifiers: [])
-            }
         
         let l = KeypadButton(label: .constant("l"), sublabel: .constant("→")) {
             sharedClient.handleShortcut(key: .l)
         }
-        .keyboardShortcut(.rightArrow, modifiers: [])
 
         
         return HStack {
@@ -135,18 +127,14 @@ struct ExtKeypad: View {
                 KeypadButton(label: .constant("r"), sublabel: .constant("reply")) {
                     sharedClient.handleShortcut(key: .r)
                 }
-                .keyboardShortcut("r", modifiers: [])
                 KeypadButton(label: .constant("f"), sublabel: .constant("favourite")) {
                     sharedClient.handleShortcut(key: .f)
                 }
-                .keyboardShortcut("f", modifiers: [])
                 KeypadButton(label: .constant("t"), sublabel: .constant("boost")) {
                     sharedClient.handleShortcut(key: .t)
                 }
-                .keyboardShortcut("t", modifiers: [])
                 KeypadButton(label: .constant("v"), sublabel: .constant("context")) {
                 }
-                .keyboardShortcut("v", modifiers: [])
                 KeypadButton(label:
                                 !sharedClient.postAreaFocused ?
                     .constant("u") : .constant("esc"),
@@ -156,10 +144,9 @@ struct ExtKeypad: View {
                 ) {
                     sharedClient.handleShortcut(key: .u)
                 }
-                .keyboardShortcut("u", modifiers: [])
-                .onLongPressGesture(minimumDuration: 0.1, maximumDistance: 0) {
-                    print("TODO: discard")
-                }
+                    .onLongPressGesture(minimumDuration: 0.1, maximumDistance: 0) {
+                        print("TODO: discard")
+                    }
             }
         }
         .padding(.horizontal, 16)

--- a/reazure/views/core/ExtKeypad.swift
+++ b/reazure/views/core/ExtKeypad.swift
@@ -187,7 +187,7 @@ struct ExtKeypad: View {
             Text("Preview of ExtKeypad")
             ExtKeypad()
                 .environmentObject(PreferencesManager())
-                .environmentObject(SharedClient())
+                .environmentObject(SharedClient.shared)
         }
         
         Spacer()

--- a/reazure/views/core/Navbar.swift
+++ b/reazure/views/core/Navbar.swift
@@ -92,7 +92,7 @@ struct Navbar: View {
 }
 
 #Preview {
-    let sharedClient = SharedClient()
+    let sharedClient = SharedClient.shared
     
     Navbar(tabSelection: .constant(.home)) { _ in
         

--- a/reazure/views/core/ShortcutHandler.swift
+++ b/reazure/views/core/ShortcutHandler.swift
@@ -1,0 +1,143 @@
+//
+//  ShortcutHandler.swift
+//  reazure
+//
+//  Created by Gyuhwan Park on 11/30/24.
+//
+
+import SwiftUI
+import UIKit
+
+class ShortcutHandlerInternal: UIViewController {
+    var sharedClient: SharedClient {
+        SharedClient.shared
+    }
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        
+        registerShortcut(.h, action: #selector(handlerH))
+        registerShortcut(.j, action: #selector(handlerJ))
+        registerShortcut(.k, action: #selector(handlerK))
+        registerShortcut(.l, action: #selector(handlerL))
+        registerShortcut(.f, action: #selector(handlerF))
+        registerShortcut(.r, action: #selector(handlerR))
+        registerShortcut(.t, action: #selector(handlerT))
+        registerShortcut(.v, action: #selector(handlerV))
+        registerShortcut(.u, action: #selector(handlerU))
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func registerShortcut(_ key: ShortcutKey, action: Selector) {
+        let command = key.asUIKeyCommand(selector: action)
+        self.addKeyCommand(command)
+    }
+    
+    override var canBecomeFirstResponder: Bool {
+        return true
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.becomeFirstResponder()
+    }
+    
+    @objc
+    func handlerH() {
+        sharedClient.handleShortcut(key: .h)
+    }
+    
+    @objc
+    func handlerJ() {
+        sharedClient.handleShortcut(key: .j)
+    }
+    
+    @objc
+    func handlerK() {
+        sharedClient.handleShortcut(key: .k)
+    }
+    
+    @objc
+    func handlerL() {
+        sharedClient.handleShortcut(key: .l)
+    }
+    
+    @objc
+    func handlerF() {
+        sharedClient.handleShortcut(key: .f)
+    }
+    
+    @objc
+    func handlerR() {
+        sharedClient.handleShortcut(key: .r)
+    }
+    
+    @objc
+    func handlerT() {
+        sharedClient.handleShortcut(key: .t)
+    }
+    
+    @objc
+    func handlerV() {
+        sharedClient.handleShortcut(key: .v)
+    }
+    
+    @objc
+    func handlerU() {
+        sharedClient.handleShortcut(key: .u)
+    }
+}
+
+struct ShortcutHandler: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> ShortcutHandlerInternal {
+        let controller = ShortcutHandlerInternal()
+        
+        return controller
+    }
+    
+    func updateUIViewController(_ uiViewController: ShortcutHandlerInternal, context: Context) {
+    }
+}
+
+fileprivate extension ShortcutKey {
+    var asUIKeyCommandInput: String {
+        switch self {
+        case .h:
+            return UIKeyCommand.inputLeftArrow
+        case .j:
+            return UIKeyCommand.inputDownArrow
+        case .k:
+            return UIKeyCommand.inputUpArrow
+        case .l:
+            return UIKeyCommand.inputRightArrow
+        case .f:
+            return "f"
+        case .r:
+            return "r"
+        case .t:
+            return "t"
+        case .v:
+            return "v"
+        case .u:
+            return "u"
+        }
+        
+    }
+    
+    func asUIKeyCommand(selector: Selector) -> UIKeyCommand {
+        let command = UIKeyCommand(
+            input: self.asUIKeyCommandInput,
+            modifierFlags: [],
+            action: selector
+        )
+        
+        command.wantsPriorityOverSystemBehavior = true
+        
+        return command
+    }
+}
+


### PR DESCRIPTION
# 개요
- iPad를 통해 실행하는 경우, 물리 키보드를 통한 조작이 불가능하던 문제를 수정합니다.
  - `View.keyboardShortcut()`을 사용한 단축키 핸들링 대신, UIKit의 UIKeyCommand를 사용하도록 하였습니다.
  - `UIKeyCommand.wantsPriorityOverSystemBehavior = true`로 설정함으로써 iPadOS의 키보드를 사용한 UI 내비게이션 동작을 오버라이드 하였습니다.